### PR TITLE
Fix outdated schema

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -9,7 +9,7 @@ To log into a Docker Registry, we recommend using the [Docker Login](../login) A
 ```
 action "build" {
   uses = "actions/docker/cli@master"
-  command = "build -t user/repo ."
+  args = "build -t user/repo ."
 }
 ```
 

--- a/tag/README.md
+++ b/tag/README.md
@@ -14,7 +14,7 @@ The tag action requires at least two arguments: the image to be tagged, that mus
 ```
 action "tag" {
   uses = "actions/docker/tag@master"
-  command = "base github/base"
+  args = "base github/base"
 }
 ```
 


### PR DESCRIPTION
Some of the docs on here are out of date. This resolves it.

`command` is now `args`

```
action "build" {
  uses = "actions/docker/cli@master"
  command = "build -t user/repo ."
}
```

should be

```
action "build" {
  uses = "actions/docker/cli@master"
  args = "build -t user/repo ."
}
```
