### PR TITLE
GitHub Action for Docker has "unsatisfiable constraints" 

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -11,7 +11,6 @@ LABEL "com.github.actions.color"="blue"
 COPY LICENSE README.md THIRD_PARTY_NOTICE.md /
 
 RUN apk update \
-  && (apk info | xargs -n1 -I{} apk --quiet add {}-doc); true \
   && rm -rf /var/cache/apk/*
 
 COPY entrypoint.sh /entrypoint.sh

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -10,9 +10,6 @@ LABEL "com.github.actions.icon"="package"
 LABEL "com.github.actions.color"="blue"
 COPY LICENSE README.md THIRD_PARTY_NOTICE.md /
 
-RUN apk update \
-  && rm -rf /var/cache/apk/*
-
 COPY entrypoint.sh /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/login/Dockerfile
+++ b/login/Dockerfile
@@ -10,7 +10,4 @@ LABEL "com.github.actions.name"="Docker Registry"
 LABEL "com.github.actions.description"="This is an Action to log into docker."
 COPY LICENSE README.md THIRD_PARTY_NOTICE.md /
 
-RUN apk update \
-  && rm -rf /var/cache/apk/*
-
 ENTRYPOINT docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD $DOCKER_REGISTRY_URL

--- a/login/Dockerfile
+++ b/login/Dockerfile
@@ -11,7 +11,6 @@ LABEL "com.github.actions.description"="This is an Action to log into docker."
 COPY LICENSE README.md THIRD_PARTY_NOTICE.md /
 
 RUN apk update \
-  && (apk info | xargs -n1 -I{} apk --quiet add {}-doc); true \
   && rm -rf /var/cache/apk/*
 
 ENTRYPOINT docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD $DOCKER_REGISTRY_URL


### PR DESCRIPTION
When attempting to run a Workflow on a repository I have for testing, I get this error in the logs stating the GitHub Action for Docker has "unsatisfiable constraints".

This is because it attempts to install a `*-doc` package regardless of whether it exists or not, this PR removes the command to install these. I'm not aware of a requirement for any doc packages to be installed - if there is I'd be happy to explicitly include those in this PR.

I've included an example failure below.

```
Step 1/12 : FROM docker:stable
stable: Pulling from library/docker
4fe2ade4980c: Already exists
2e793f0ebe8a: Already exists
77995fba1918: Already exists
138bee096c72: Pulling fs layer
5ed9d4b111c6: Pulling fs layer
0fc49bcc693c: Pulling fs layer
0fc49bcc693c: Download complete
5ed9d4b111c6: Verifying Checksum
5ed9d4b111c6: Download complete
138bee096c72: Verifying Checksum
138bee096c72: Download complete
138bee096c72: Pull complete
5ed9d4b111c6: Pull complete
0fc49bcc693c: Pull complete
Digest: sha256:673cb8cd5bb1120a5279809d3011c850ce078ae6862e1e701141b3db76e6e9cb
Status: Downloaded newer image for docker:stable
 ---> 062267097b77
Step 2/12 : LABEL "name"="Docker CLI Action"
 ---> Running in caf93b360bee
Removing intermediate container caf93b360bee
 ---> 47aafe1ce62a
Step 3/12 : LABEL "maintainer"="GitHub Actions <support+actions@github.com>"
 ---> Running in 7d13a4eaa004
Removing intermediate container 7d13a4eaa004
 ---> c9ef8565a71c
Step 4/12 : LABEL "version"="1.0.0"
 ---> Running in cfea32798e9f
Removing intermediate container cfea32798e9f
 ---> 61e39e9b6bec
Step 5/12 : LABEL "com.github.actions.name"="GitHub Action for Docker"
 ---> Running in 0e0f87c6d5af
Removing intermediate container 0e0f87c6d5af
 ---> 62879eab3cb9
Step 6/12 : LABEL "com.github.actions.description"="Wraps the Docker CLI to enable Docker commands."
 ---> Running in 53418c6310cc
Removing intermediate container 53418c6310cc
 ---> f8b969d70018
Step 7/12 : LABEL "com.github.actions.icon"="package"
 ---> Running in ea33f2fc5dda
Removing intermediate container ea33f2fc5dda
 ---> fd292d20774c
Step 8/12 : LABEL "com.github.actions.color"="blue"
 ---> Running in c3b0e41b4cb5
Removing intermediate container c3b0e41b4cb5
 ---> c732035bc712
Step 9/12 : COPY LICENSE README.md THIRD_PARTY_NOTICE.md /
 ---> 8e2c9113abc1
Step 10/12 : RUN apk update   && (apk info | xargs -n1 -I{} apk --quiet add {}-doc); true   && rm -rf /var/cache/apk/*
 ---> Running in a186edf1b7f5
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
v3.8.1-93-g4edf9b0a68 [http://dl-cdn.alpinelinux.org/alpine/v3.8/main]
v3.8.1-91-gdf12aa925f [http://dl-cdn.alpinelinux.org/alpine/v3.8/community]
OK: 9546 distinct packages available
ERROR: unsatisfiable constraints:
  musl-doc (missing):
    required by: world[musl-doc]
ERROR: unsatisfiable constraints:
  busybox-doc (missing):
    required by: world[busybox-doc]
ERROR: unsatisfiable constraints:
  alpine-baselayout-doc (missing):
    required by: world[alpine-baselayout-doc]
ERROR: unsatisfiable constraints:
  alpine-keys-doc (missing):
    required by: world[alpine-keys-doc]
ERROR: unsatisfiable constraints:
  libressl2.7-libcrypto-doc (missing):
    required by: world[libressl2.7-libcrypto-doc]
ERROR: unsatisfiable constraints:
  libressl2.7-libssl-doc (missing):
    required by: world[libressl2.7-libssl-doc]
ERROR: unsatisfiable constraints:
  libressl2.7-libtls-doc (missing):
    required by: world[libressl2.7-libtls-doc]
ERROR: unsatisfiable constraints:
  ssl_client-doc (missing):
    required by: world[ssl_client-doc]
ERROR: unsatisfiable constraints:
  apk-tools-doc (missing):
    required by: world[apk-tools-doc]
ERROR: unsatisfiable constraints:
  scanelf-doc (missing):
    required by: world[scanelf-doc]
ERROR: unsatisfiable constraints:
  musl-utils-doc (missing):
    required by: world[musl-utils-doc]
ERROR: unsatisfiable constraints:
  libc-utils-doc (missing):
    required by: world[libc-utils-doc]
Removing intermediate container a186edf1b7f5
 ---> 9e5637727360
Step 11/12 : COPY entrypoint.sh /entrypoint.sh
 ---> a0b80d694af0
Step 12/12 : ENTRYPOINT ["/entrypoint.sh"]
 ---> Running in fc4296e2f345
```
