### PR TITLE
Install bash into Docker CLI action image

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -8,6 +8,9 @@ LABEL "com.github.actions.name"="GitHub Action for Docker"
 LABEL "com.github.actions.description"="Wraps the Docker CLI to enable Docker commands."
 LABEL "com.github.actions.icon"="package"
 LABEL "com.github.actions.color"="blue"
+
+RUN apk add bash
+
 COPY LICENSE README.md THIRD_PARTY_NOTICE.md /
 
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
I've had a need to run a script having bash-specific syntax so I thought it'd be good to add it upstream...