### PR TITLE
Update SHA documentation to seven characters not six

### DIFF
--- a/tag/README.md
+++ b/tag/README.md
@@ -21,7 +21,7 @@ action "tag" {
 This will look at the following:
 
 * `GITHUB_REF` environment variable, turning `heads/refs/master` -> `master`
-* `GITHUB_SHA` taking the first six characters
+* `GITHUB_SHA` taking the first seven characters
 * `version` `LABEL` from the Dockerfile
 
 It is possible to disable these tags by passing:


### PR DESCRIPTION
GitHub lists the first seven characters of the SHA throughout the site and during this tag operation, not six. Updates the documentation to seven to reflect that.