### PR TITLE
Switch docker login to --password-stdin

### DIFF
--- a/login/Dockerfile
+++ b/login/Dockerfile
@@ -10,4 +10,4 @@ LABEL "com.github.actions.name"="Docker Registry"
 LABEL "com.github.actions.description"="This is an Action to log into docker."
 COPY LICENSE README.md THIRD_PARTY_NOTICE.md /
 
-ENTRYPOINT docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD $DOCKER_REGISTRY_URL
+ENTRYPOINT echo "$DOCKER_PASSWORD" | docker login $DOCKER_REGISTRY_URL -u $DOCKER_USERNAME --password-stdin


### PR DESCRIPTION
This is my attempt to use a more secure approach to pass password for CI environments

See #20 and https://stackoverflow.com/questions/51489359/docker-using-password-via-the-cli-is-insecure-use-password-stdin